### PR TITLE
InputSchema for get-unread-emails does not pass validation

### DIFF
--- a/src/gmail/server.py
+++ b/src/gmail/server.py
@@ -392,8 +392,8 @@ async def main(creds_file_path: str,
                 description="Retrieve unread emails",
                 inputSchema={
                     "type": "object",
-                    "properties": {"":""},
-                    "required": None
+                    "properties": {},
+                    "required": []
                 },
             ),
             types.Tool(


### PR DESCRIPTION
The following inputSchema fails validation when marshalling to JSON when performing <code>POST https://api.anthropic.com/v1/messages </code>

```
inputSchema={
                    "type": "object",
                    "properties": {"":""},
                    "required": None
                }
```
The validation failure is due to the following reasons, 
1.  The `properties` dictionary with empty values fails ```Ensure tools.2.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_-]{1,64}$```
2. The `required` key does not marshall to JSON correctly since its value of `None` is not a valid JSON value.