### PR TITLE
Handle more inbox categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ https://github.com/user-attachments/assets/5794cd16-00d2-45a2-884a-8ba0c3a90c90
 
 - **get-unread-emails**
   - Retrieves unread emails 
+  - Input:
+    - `category` (optional string): Category of the unread emails. 
   - Returns list of emails including email ID
 
 - **read-email**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "httpx>=0.28.1",
     "mcp>=1.1.2",
+    "python-dotenv>=1.0.0",
     "google-api-python-client>=2.156.0",
     "google-auth-httplib2>=0.2.0",
     "google-auth-oauthlib>=1.2.1",


### PR DESCRIPTION
The existing implementation of `get-unread-emails` assumes that the Gmail query string is <code>in:inbox is:unread category:primary</code>. The pull request keeps the <code>category: primary</code> query string as default. The change adds a setting to override the default by changing the environment variable <code>UNREAD_EMAILS_CATEGORY</code>.